### PR TITLE
Fix version regex for multi-line version files

### DIFF
--- a/get_releasenote.py
+++ b/get_releasenote.py
@@ -174,8 +174,9 @@ def check_changes_version(
 VERSION_RE = re.compile(
     "^{version} *= *{spec}".format(
         version="(?:__version__|version)",
-        spec=r"""(['"])([^\1]+)\1""",
-    )
+        spec=r"""(["'])((?:(?!\1).)*)\1""",
+    ),
+    re.MULTILINE,
 )
 
 
@@ -193,8 +194,7 @@ def find_version(ctx: Context, version_file: str, version: str) -> str:
             )
         return version
     txt = ctx.read_file(version_file)
-    match = VERSION_RE.match(txt)
-    if match:
+    if match := VERSION_RE.search(txt):
         ret = match.group(2)
         if ctx.dist and ret != ctx.dist.version:
             raise ValueError(
@@ -202,8 +202,7 @@ def find_version(ctx: Context, version_file: str, version: str) -> str:
                 f"mismatches with autodetected {ctx.dist.version}"
             )
         return ret
-    else:
-        raise ValueError(f"Unable to determine version in file '{version_file}'")
+    raise ValueError(f"Unable to determine version in file '{version_file}'")
 
 
 def check_fix_issue(fix_issue_regex: str, fix_issue_repl: str) -> None:

--- a/tests/test_find_version.py
+++ b/tests/test_find_version.py
@@ -4,6 +4,14 @@ import pytest
 
 from get_releasenote import Context, DistInfo, analyze_dists, find_version
 
+VERSION_FILE_TMPL = """\
+from ._inner import Foo, Bar, spam_ham
+
+{version_line}
+
+__all__ = ("Foo", "Bar", "spam_ham")
+"""
+
 
 @pytest.fixture
 def root() -> pathlib.Path:
@@ -28,7 +36,9 @@ def test_find_version_autodetected(ctx: Context) -> None:
 
 def test_find_version_ambigous(ctx: Context) -> None:
     with pytest.raises(ValueError, match="ambiguous"):
-        (ctx.root / "file.py").write_text("__version__='1.2.3'")
+        (ctx.root / "file.py").write_text(
+            VERSION_FILE_TMPL.format(version_line="__version__='1.2.3'")
+        )
         find_version(ctx, "file.py", "3.4.5")
 
 
@@ -43,36 +53,60 @@ def test_find_version_explicit(ctx: Context) -> None:
 
 def test_find_version_file_mismatch_with_autodetected(ctx: Context) -> None:
     with pytest.raises(ValueError, match="mismatches with autodetected "):
-        (ctx.root / "file.py").write_text("__version__='1.2.3'")
+        (ctx.root / "file.py").write_text(
+            VERSION_FILE_TMPL.format(version_line="__version__='1.2.3'")
+        )
         find_version(ctx, "file.py", "")
 
 
 def test_find___version___no_spaces(ctx: Context) -> None:
-    (ctx.root / "file.py").write_text("__version__='0.0.7'")
+    (ctx.root / "file.py").write_text(
+        VERSION_FILE_TMPL.format(version_line="__version__='0.0.7'")
+    )
     assert "0.0.7" == find_version(ctx, "file.py", "")
 
 
 def test_find___version___from_file_single_quotes(ctx: Context) -> None:
-    (ctx.root / "file.py").write_text("__version__ = '0.0.7'")
+    (ctx.root / "file.py").write_text(
+        VERSION_FILE_TMPL.format(version_line="__version__ = '0.0.7'")
+    )
     assert "0.0.7" == find_version(ctx, "file.py", "")
 
 
 def test_find___version___from_file_double_quotes(ctx: Context) -> None:
-    (ctx.root / "file.py").write_text('__version__ = "0.0.7"')
+    (ctx.root / "file.py").write_text(
+        VERSION_FILE_TMPL.format(version_line='__version__ = "0.0.7"')
+    )
     assert "0.0.7" == find_version(ctx, "file.py", "")
 
 
 def test_find_version_from_file_single_quotes(ctx: Context) -> None:
-    (ctx.root / "file.py").write_text("version = '0.0.7'")
+    (ctx.root / "file.py").write_text(
+        VERSION_FILE_TMPL.format(version_line="version = '0.0.7'")
+    )
     assert "0.0.7" == find_version(ctx, "file.py", "")
 
 
 def test_find_version_from_file_double_quotes(ctx: Context) -> None:
-    (ctx.root / "file.py").write_text('version = "0.0.7"')
+    (ctx.root / "file.py").write_text(
+        VERSION_FILE_TMPL.format(version_line="version = '0.0.7'")
+    )
     assert "0.0.7" == find_version(ctx, "file.py", "")
 
 
 def test_find_version_not_found(ctx: Context) -> None:
-    (ctx.root / "file.py").write_text("not_a_version = '0.0.7'")
+    (ctx.root / "file.py").write_text(
+        VERSION_FILE_TMPL.format(version_line="not_a_version = '0.0.7'")
+    )
     with pytest.raises(ValueError, match="Unable to determine version"):
         find_version(ctx, "file.py", "")
+
+
+@pytest.mark.parametrize("quote", ["'", '"'])
+def test_find_version_with_quote_in_comment(ctx: Context, quote: str) -> None:
+    (ctx.root / "file.py").write_text(
+        VERSION_FILE_TMPL.format(
+            version_line="version = '0.0.7'  # don't forget to update!"
+        ).replace("'", quote)
+    )
+    assert "0.0.7" == find_version(ctx, "file.py", "")


### PR DESCRIPTION
## What do these changes do?

The version regex has several issues, primarily because it assumes the version file consists of a single line. This broke the [Yarl 1.8 release](https://github.com/aio-libs/yarl/issues/698); this PR fixes the issue.

- Expand version tests to use a multi-line mock-module text as base.
- Add a test with matching quote following version string to verify the backref is working
  correctly.
- add `re.MULTILINE` flag so `^` matches right after a newline, not just the
  start of the text.
- Use a negative lookahead assertion against the backref, instead of a backref
  inside a character class. Character classes don't support backrefs.
- Use `.search()` instead of `.match()`; we need to find the pattern anywhere
  in the version file, not just the start.
- Add missing `INPUT_CHECK_REF` env var to `runs:` section.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
