### PR TITLE
Clean up pre-commit and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,13 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/checkout@v3
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.9
-    - name: Cache PyPI
-      uses: actions/cache@v2
-      with:
-        key: pip-lint-${{ hashFiles('requirements.txt') }}
-        path: ~/.cache/pip
-        restore-keys: |
-            pip-lint-
+        python-version: "3.10"
+        cache: 'pip'
+        cache-dependency-path: 'requirements.txt'
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v3
       with:
@@ -47,29 +42,17 @@ jobs:
 
   test:
     name: Test
-    strategy:
-      matrix:
-        pyver: ['3.7', '3.8', '3.9', '3.10']
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup Python ${{ matrix.pyver }}
-      uses: actions/setup-python@v2
+      uses: actions/checkout@v3
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.pyver }}
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
-    - name: Cache PyPI
-      uses: actions/cache@v2
-      with:
-        key: pip-ci-${{ matrix.pyver }}-${{ hashFiles('requirements.txt') }}
-        path: ${{ steps.pip-cache.outputs.dir }}
-        restore-keys: |
-            pip-ci-${{ matrix.pyver }}-
+        python-version: "3.10"
+        cache: 'pip'
+        cache-dependency-path: 'requirements.txt'
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v3
       with:
@@ -86,14 +69,3 @@ jobs:
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
-
-  check:  # This job does nothing and is only used for the branch protection
-    if: always()
-    name: "Tests check"
-    needs: [lint, test]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: '21.12b0'
+  rev: '22.3.0'
   hooks:
     - id: black
       language_version: python3 # Should be a command that runs python3.6+
@@ -61,7 +61,7 @@ repos:
   - id: flake8
     exclude: "^docs/"
 
-- repo: git://github.com/Lucas-C/pre-commit-hooks-markup
+- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
   rev: v1.0.1
   hooks:
   - id: rst-linter


### PR DESCRIPTION
## What do these changes do?

- Use Python 3.10 only (matching the Python version in the action dockerfile)
- Use https:// URLs only for pre-commit hooks

NOTE: You'll have to update the 'required' settings for the repo, as the 'check' job was dropped with the matrix gone.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
