### PR TITLE
Fix the towncrier link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,4 @@ get-releasenote
 GitHub action for getting release note from towncrier_ rendered file.
 
 
-.. _towncrier: https://towncrier.readthedocs.io/en/actual-freaking-docs/
+.. _towncrier: https://towncrier.readthedocs.io/en/stable/


### PR DESCRIPTION
## What do these changes do?

These changes fix a broken link to `towncrier`'s documentation.

## Are there changes in behavior for the user?

Link from the [README.rst](https://github.com/aio-libs/get-releasenote/blob/master/README.rst) to `towncrier`'s documentation will be fixed.

## Related issue number

Similar PR:
  * aio-libs/frozenlist#574

## Checklist

- [x] I think the code is well written
- [x] ~Unit tests for the changes exist~
- [x] Documentation reflects the changes

_Best regards!_
